### PR TITLE
Use generics for json encode

### DIFF
--- a/lib/annotation.dart
+++ b/lib/annotation.dart
@@ -5,8 +5,8 @@ abstract class Accessor<V1,V2> {
   V2 set(V1 value);
 }
 
-abstract class JSONEncoder{
-  dynamic encode(dynamic value);
+abstract class JSONEncoder<V1, V2>{
+  V1 encode(V2 value);
 }
 
 abstract class Serialize{


### PR DESCRIPTION
if you extends JSONEncoder and want to override encode method and specify types, dart analyzer in strong find errors. Generics allow to specify types without analuzer errors.